### PR TITLE
Use not deprecated `repo update`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ To use the charts here first add the fpco helm repo:
 
 ```
 helm repo add fpco https://s3.amazonaws.com/fpco-charts/stable/
-helm update
+helm repo update
 ```


### PR DESCRIPTION
I looks that already in helm-2.1 `helm update`  was deprecated and the docs commit https://github.com/helm/helm/commit/aca9f86df62f6ff13fdade755ece70d25bdfe079 was done more than 2.5 years ago