### PR TITLE
Fix basic auth in monitoring chart

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -101,7 +101,7 @@ to them we put `basic auth` in front (this will likely change soon).
 To create a basic auth file use `htpasswd -c ./auth admin`, enter a password and then run:
 
 ```
-kubectl create secret generic basic-auth --from-file=auth
+kubectl create secret generic basic-auth --from-file=auth --namespace=monitoring
 ```
 
 `NOTE`: when creating the basic auth file with `htpasswd -c ./auth admin` it's important to name the file just `auth`.

--- a/monitoring/settings.yaml.example
+++ b/monitoring/settings.yaml.example
@@ -44,7 +44,7 @@ prometheus:
       kubernetes.io/ingress.class: "nginx"
       kubernetes.io/tls-acme: "true"
       nginx.ingress.kubernetes.io/auth-type: basic
-      nginx.ingress.kubernetes.io/auth-secret: monitoring-basic-auth
+      nginx.ingress.kubernetes.io/auth-secret: basic-auth
       nginx.ingress.kubernetes.io/auth-realm: "FPCO Monitoring - Authentication Required"
       ingress.kubernetes.io/rewrite-target: "/"
     tls:


### PR DESCRIPTION
settings and README were inconsistent one with another and also namespace is required here.
Also I don't quite understand the meaning of the note in the basic auth section of README